### PR TITLE
Refactor SHAP explainability into `src/explain` module

### DIFF
--- a/scripts/03_xgb_explainability_shap.py
+++ b/scripts/03_xgb_explainability_shap.py
@@ -35,11 +35,16 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
-import shap
 from sklearn.datasets import make_classification
 from sklearn.model_selection import train_test_split
 from xgboost import XGBClassifier
 from src.utils import ensure_timestamped_dir
+from src.explain import (
+    compute_tree_shap,
+    shap_summary,
+    shap_dependence,
+    shap_local_waterfall,
+)
 
 
 @dataclass
@@ -63,13 +68,6 @@ class Config:
     instance_idx: int = 0
     # IO
     output_dir: Path = Path("runs")
-
-
-def ensure_output_dir(root: Path) -> Path:
-    ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    p = root / ts / "explainability"
-    p.mkdir(parents=True, exist_ok=True)
-    return p
 
 
 def make_data(cfg: Config):
@@ -108,92 +106,6 @@ def train_xgb(cfg: Config, X_train: np.ndarray, y_train: np.ndarray, X_val: np.n
     )
     model.fit(X_train, y_train, eval_set=[(X_val, y_val)], verbose=False)
     return model
-
-
-def compute_shap(model: XGBClassifier, X_train: np.ndarray, X_test: np.ndarray):
-    # Use TreeExplainer for tree models (fast exact/approx)
-    explainer = shap.TreeExplainer(model, feature_perturbation="interventional")
-    shap_values = explainer.shap_values(X_test)
-    # For binary classification, shap_values is array of shape (n_samples, n_features)
-    # Ensure we handle potential list output format from older versions
-    if isinstance(shap_values, list):
-        if len(shap_values) > 1:
-            warnings.warn(
-                f"Detected multi-class SHAP output (len={len(shap_values)}). "
-                "This script expects binary classification. Please check your model and data.",
-                RuntimeWarning,
-            )
-        shap_values = shap_values[0]
-    expected_value = explainer.expected_value
-    if isinstance(expected_value, (list, tuple)):
-        expected_value = expected_value[0]
-    return explainer, shap_values, expected_value
-
-
-def plot_summary(shap_values: np.ndarray, X_test: np.ndarray, feature_names: list[str], out_dir: Path) -> None:
-    shap.summary_plot(shap_values, X_test, feature_names=feature_names, show=False)
-    plt.tight_layout()
-    plt.savefig(out_dir / "shap_summary_beeswarm.png", dpi=150, bbox_inches="tight")
-    plt.close()
-
-    shap.summary_plot(shap_values, X_test, feature_names=feature_names, plot_type="bar", show=False)
-    plt.tight_layout()
-    plt.savefig(out_dir / "shap_summary_bar.png", dpi=150, bbox_inches="tight")
-    plt.close()
-
-
-def plot_dependence(
-    shap_values: np.ndarray,
-    X_test: np.ndarray,
-    feature_names: list[str],
-    top_k: int,
-    out_dir: Path,
-) -> None:
-    # Rank by mean absolute SHAP
-    mean_abs = np.mean(np.abs(shap_values), axis=0)
-    top_idx = np.argsort(mean_abs)[::-1][:top_k]
-
-    for idx in top_idx:
-        shap.dependence_plot(
-            ind=idx,
-            shap_values=shap_values,
-            features=X_test,
-            feature_names=feature_names,
-            show=False,
-            interaction_index="auto",
-        )
-        plt.tight_layout()
-        plt.savefig(out_dir / f"dependence_{feature_names[idx]}.png", dpi=150, bbox_inches="tight")
-        plt.close()
-
-
-def plot_local(
-    explainer: shap.TreeExplainer,
-    expected_value: float,
-    shap_values: np.ndarray,
-    X_test: np.ndarray,
-    feature_names: list[str],
-    instance_idx: int,
-    out_dir: Path,
-) -> None:
-    if instance_idx < 0 or instance_idx >= len(X_test):
-        raise IndexError(
-            f"instance-idx {instance_idx} out of bounds for test set size {len(X_test)}"
-        )
-    idx = int(instance_idx)
-    shap.waterfall_plot(
-        shap.Explanation(
-            values=shap_values[idx],
-            base_values=expected_value,
-            data=X_test[idx],
-            feature_names=feature_names,
-        ),
-        show=False,
-        max_display=14,
-    )
-    plt.tight_layout()
-    plt.savefig(out_dir / f"local_waterfall_idx_{idx}.png", dpi=150, bbox_inches="tight")
-    plt.close()
 
 
 def parse_args() -> Config:
@@ -246,11 +158,11 @@ def main() -> None:
     X_train, X_val, X_test, y_train, y_val, y_test, feature_names = make_data(cfg)
     model = train_xgb(cfg, X_train, y_train, X_val, y_val)
 
-    explainer, shap_values, expected_value = compute_shap(model, X_train, X_test)
+    explainer, shap_values, expected_value = compute_tree_shap(model, X_test)
 
-    plot_summary(shap_values, X_test, feature_names, out_dir)
-    plot_dependence(shap_values, X_test, feature_names, cfg.top_k, out_dir)
-    plot_local(explainer, expected_value, shap_values, X_test, feature_names, cfg.instance_idx, out_dir)
+    shap_summary(shap_values, X_test, feature_names, out_dir)
+    shap_dependence(shap_values, X_test, feature_names, cfg.top_k, out_dir)
+    shap_local_waterfall(explainer, expected_value, shap_values, X_test, feature_names, cfg.instance_idx, out_dir)
 
     print(f"Saved SHAP visuals to: {out_dir}")
 

--- a/src/explain.py
+++ b/src/explain.py
@@ -49,7 +49,9 @@ def shap_dependence(
     out_dir: Path,
 ) -> None:
     mean_abs = np.mean(np.abs(shap_values), axis=0)
-    top_idx = np.argsort(mean_abs)[::-1][:top_k]
+    n_features = len(feature_names)
+    k = max(0, min(top_k, n_features))
+    top_idx = np.argsort(mean_abs)[::-1][:k]
 
     for idx in top_idx:
         shap.dependence_plot(
@@ -74,9 +76,9 @@ def shap_local_waterfall(
     instance_idx: int,
     out_dir: Path,
 ) -> None:
-    if instance_idx < 0 or instance_idx >= len(X):
-        raise IndexError(f"instance-idx {instance_idx} out of bounds for test set size {len(X)}")
     idx = int(instance_idx)
+    if idx < 0 or idx >= len(X):
+        raise IndexError(f"instance-idx {instance_idx} out of bounds for test set size {len(X)}")
     shap.waterfall_plot(
         shap.Explanation(
             values=shap_values[idx],

--- a/src/explain.py
+++ b/src/explain.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import shap
+
+
+def compute_tree_shap(model, X_test):
+    """Return (explainer, shap_values, expected_value) for tree models.
+
+    Handles SHAP API variations and multi-class list outputs by selecting the
+    first class and warning the user via print (kept minimal to avoid logger deps).
+    """
+    explainer = shap.TreeExplainer(model, feature_perturbation="interventional")
+    shap_values = explainer.shap_values(X_test)
+    if isinstance(shap_values, list):
+        if len(shap_values) > 1:
+            print(f"Warning: multi-class SHAP output (len={len(shap_values)}); using class 0.")
+        shap_values = shap_values[0]
+    expected_value = explainer.expected_value
+    if isinstance(expected_value, (list, tuple)):
+        expected_value = expected_value[0]
+    return explainer, shap_values, expected_value
+
+
+def shap_summary(shap_values, X, feature_names: List[str], out_dir: Path) -> None:
+    shap.summary_plot(shap_values, X, feature_names=feature_names, show=False)
+    plt.tight_layout()
+    plt.savefig(out_dir / "shap_summary_beeswarm.png", dpi=150, bbox_inches="tight")
+    plt.close()
+
+    shap.summary_plot(shap_values, X, feature_names=feature_names, plot_type="bar", show=False)
+    plt.tight_layout()
+    plt.savefig(out_dir / "shap_summary_bar.png", dpi=150, bbox_inches="tight")
+    plt.close()
+
+
+def shap_dependence(
+    shap_values,
+    X,
+    feature_names: List[str],
+    top_k: int,
+    out_dir: Path,
+) -> None:
+    mean_abs = np.mean(np.abs(shap_values), axis=0)
+    top_idx = np.argsort(mean_abs)[::-1][:top_k]
+
+    for idx in top_idx:
+        shap.dependence_plot(
+            ind=idx,
+            shap_values=shap_values,
+            features=X,
+            feature_names=feature_names,
+            show=False,
+            interaction_index="auto",
+        )
+        plt.tight_layout()
+        plt.savefig(out_dir / f"dependence_{feature_names[idx]}.png", dpi=150, bbox_inches="tight")
+        plt.close()
+
+
+def shap_local_waterfall(
+    explainer: shap.TreeExplainer,
+    expected_value: float,
+    shap_values,
+    X,
+    feature_names: List[str],
+    instance_idx: int,
+    out_dir: Path,
+) -> None:
+    if instance_idx < 0 or instance_idx >= len(X):
+        raise IndexError(f"instance-idx {instance_idx} out of bounds for test set size {len(X)}")
+    idx = int(instance_idx)
+    shap.waterfall_plot(
+        shap.Explanation(
+            values=shap_values[idx],
+            base_values=expected_value,
+            data=X[idx],
+            feature_names=feature_names,
+        ),
+        show=False,
+        max_display=14,
+    )
+    plt.tight_layout()
+    plt.savefig(out_dir / f"local_waterfall_idx_{idx}.png", dpi=150, bbox_inches="tight")
+    plt.close()


### PR DESCRIPTION
## Summary by Sourcery

Modularize SHAP explainability logic by extracting computation and plotting routines into a standalone module and update the XGBoost explainability script to use the new helpers

Enhancements:
- Extract SHAP computation and visualization functions into a new `src/explain.py` module
- Rename and simplify SHAP utility functions (compute_tree_shap, shap_summary, shap_dependence, shap_local_waterfall) and update their usage in the script
- Remove inline SHAP helper definitions and the `ensure_output_dir` function from the script